### PR TITLE
Add option to ignore whitespaces during comparison

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -14,6 +14,7 @@ let receiveText = document.getElementById("receiveText");
 let inputText = document.getElementById("inputText");
 let connectButton = document.getElementById("connectButton");
 let showReceivedCheckbox = document.getElementById("showReceivedCheckbox");
+let ignoreWhitespaceCheckbox = document.getElementById("ignoreWhitespaceCheckbox");
 let autoHideCheckbox = document.getElementById("autoHideCheckbox");
 let statusBar = document.getElementById("statusBar");
 let clearAllButton = document.getElementById("clearAllButton");
@@ -26,6 +27,7 @@ let correctPercentage = document.getElementById("correctPercentage");
 let compareTextsButton = document.getElementById("compareTextsButton");
 
 let lastPercentage;
+let ignoreWhitespace = true;
 
 let ctx = document.getElementById('savedResultChart');
 let savedResultChart = new Chart(ctx, {
@@ -90,6 +92,7 @@ showSavedResults(JSON.parse(localStorage.getItem(storageKey)));
 connectButton.addEventListener("click", clickConnect)
 
 showReceivedCheckbox.addEventListener("change", clickShowReceived);
+ignoreWhitespaceCheckbox.addEventListener("change", clickIgnoreWhitespace);
 clearAllButton.addEventListener("click", clearTextFields);
 clearReceivedButton.addEventListener("click", clearReceivedTextField);
 compareTextsButton.addEventListener("click", compareTexts);
@@ -121,10 +124,20 @@ function clickShowReceived() {
     }
 }
 
+function clickIgnoreWhitespace() {
+    ignoreWhitespace = ignoreWhitespaceCheckbox.checked;
+    console.log('ignore whitespace: ', ignoreWhitespace);
+    compareTexts();
+}
 
 function compareTexts() {
     let received = trimReceivedText(receiveText.value).toLowerCase();
     let input = inputText.value.trim().toLowerCase();
+
+    if(ignoreWhitespace) {
+        received = received.replace(/\s/g,"");
+        input = input.replace(/\s/g,"");
+    }
 
     let [elements, correctCount] = createHtmlForComparedText(received, input);
 

--- a/index.html
+++ b/index.html
@@ -145,6 +145,10 @@
                 <label class="form-check-label" for="showReceivedCheckbox">Show comparision received/input and received text from Morserino</label>
             </div>
             <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" checked id="ignoreWhitespaceCheckbox">
+                <label class="form-check-label" for="ignoreWhitespaceCheckbox">Ignore whitespace during comparison</label>
+            </div>
+            <div class="form-check form-switch">
                 <input class="form-check-input" type="checkbox" checked id="autoHideCheckbox">
                 <label class="form-check-label" for="autoHideCheckbox">Auto hide during reception (between receiving 'vvv&lt;ka&gt;' and '+')</label>
             </div>

--- a/morserino32-trainer.js
+++ b/morserino32-trainer.js
@@ -13,6 +13,7 @@ let receiveText = document.getElementById("receiveText");
 let inputText = document.getElementById("inputText");
 let connectButton = document.getElementById("connectButton");
 let showReceivedCheckbox = document.getElementById("showReceivedCheckbox");
+let ignoreWhitespaceCheckbox = document.getElementById("ignoreWhitespaceCheckbox");
 let autoHideCheckbox = document.getElementById("autoHideCheckbox");
 let statusBar = document.getElementById("statusBar");
 let clearAllButton = document.getElementById("clearAllButton");
@@ -25,6 +26,7 @@ let correctPercentage = document.getElementById("correctPercentage");
 let compareTextsButton = document.getElementById("compareTextsButton");
 
 let lastPercentage;
+let ignoreWhitespace = true;
 
 let ctx = document.getElementById('savedResultChart');
 let savedResultChart = new Chart(ctx, {
@@ -89,6 +91,7 @@ showSavedResults(JSON.parse(localStorage.getItem(storageKey)));
 connectButton.addEventListener("click", clickConnect)
 
 showReceivedCheckbox.addEventListener("change", clickShowReceived);
+ignoreWhitespaceCheckbox.addEventListener("change", clickIgnoreWhitespace);
 clearAllButton.addEventListener("click", clearTextFields);
 clearReceivedButton.addEventListener("click", clearReceivedTextField);
 compareTextsButton.addEventListener("click", compareTexts);
@@ -120,10 +123,20 @@ function clickShowReceived() {
     }
 }
 
+function clickIgnoreWhitespace() {
+    ignoreWhitespace = ignoreWhitespaceCheckbox.checked;
+    console.log('ignore whitespace: ', ignoreWhitespace);
+    compareTexts();
+}
 
 function compareTexts() {
     let received = trimReceivedText(receiveText.value).toLowerCase();
     let input = inputText.value.trim().toLowerCase();
+
+    if(ignoreWhitespace) {
+        received = received.replace(/\s/g,"");
+        input = input.replace(/\s/g,"");
+    }
 
     let [elements, correctCount] = createHtmlForComparedText(received, input);
 


### PR DESCRIPTION
I am at a very early stage of learning Morse code and I mess up my spacing all the time. For a "Your Input" of "M MM" I would for now be equally happy with "M M M" or "MM M". However, the comparison does care about whitespace and gives me the following results:
![image](https://user-images.githubusercontent.com/1277653/151073280-f0c3a3a5-1724-475a-b2e8-10f0756b47c1.png)
or
![image](https://user-images.githubusercontent.com/1277653/151073367-f2480e80-2f8a-4c54-93fe-5884f94c53a3.png)
Both results are of course technically correct, and I fully understand where they come from. Still, I find the second one confusing (four 'M's in the result when the compared texts each have only three of them).

So instead of practicing to improve my timing, I implemented an option to "Ignore whitespace during comparison" ...
![image](https://user-images.githubusercontent.com/1277653/151075181-d47eb1e9-3b1e-492d-bfaa-3ccf17e8b1a4.png)
... to get the following result:
![image](https://user-images.githubusercontent.com/1277653/151075214-fa32c5e2-7b33-4e84-a773-591caf8fd408.png)

73 de OE6WCB